### PR TITLE
Replace deprecated terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ on how to get the "Fast remote polling" working.
 
 ## Version History
 
-[GitHub releases](https://github.com/jenkinsci/slave-setup-plugin/releases) provides changelogs for recent releases.
+[GitHub releases](https://github.com/jenkinsci/agent-setup-plugin/releases) provides changelogs for recent releases.
 
-[CHANGELOG](https://github.com/jenkinsci/slave-setup-plugin/blob/slave-setup-1.12/CHANGELOG.md) provides changelogs for releases before 2014.
+[CHANGELOG](https://github.com/jenkinsci/agent-setup-plugin/blob/slave-setup-1.12/CHANGELOG.md) provides changelogs for releases before 2014.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>slave-setup</artifactId>
     <packaging>hpi</packaging>
     <name>Agent Setup</name>
-    <url>https://github.com/jenkinsci/slave-setup-plugin</url>
+    <url>https://github.com/jenkinsci/agent-setup-plugin</url>
     <version>${revision}${changelist}</version>
 
     <developers>
@@ -62,7 +62,7 @@
     <properties>
         <revision>1.17</revision>
         <changelist>-SNAPSHOT</changelist>
-        <gitHubRepo>jenkinsci/slave-setup-plugin</gitHubRepo>
+        <gitHubRepo>jenkinsci/agent-setup-plugin</gitHubRepo>
         <jenkins.version>2.387.3</jenkins.version>
     </properties>
 


### PR DESCRIPTION
If you search for the repository of this plugin, the deprecated term is still displayed prominently high within the search results.

While we can't change the artifactId easily, we could update the repository's name to reflect the proper name of the plugin, and stop promoting a deprecated term, if that's within the interest of the plugin maintainers?