### PR TITLE
Require Jenkins 2.479.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,37 +14,6 @@
     <url>https://github.com/jenkinsci/agent-setup-plugin</url>
     <version>${revision}${changelist}</version>
 
-    <developers>
-        <developer>
-            <id>peppe</id>
-            <name>Giuseppe Landolfi</name>
-            <email>giuseppe.landolfi@gmail.com</email>
-        </developer>
-     </developers>
-
-    <contributors>
-        <contributor>
-            <name>Mikel Royo</name>
-            <email>mikel.royo@byteheed.com</email>
-            <organization>ByteHeed</organization>
-            <organizationUrl>https://www.byteheed.com</organizationUrl>
-            <roles>
-                <role>Developer</role>
-            </roles>
-            <timezone>Europe/Madrid</timezone>
-        </contributor>
-        <contributor>
-            <name>Aaron Giovannini</name>
-            <email>aaron.giovannini@byteheed.com</email>
-            <organization>ByteHeed</organization>
-            <organizationUrl>https://www.byteheed.com</organizationUrl>
-            <roles>
-                <role>Code Analyst</role>
-            </roles>
-            <timezone>Europe/Madrid</timezone>
-        </contributor>
-    </contributors>
-
     <scm>
         <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
         <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <revision>1.17</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/agent-setup-plugin</gitHubRepo>
-        <jenkins.baseline>2.387</jenkins.baseline>
+        <jenkins.baseline>2.479</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.7</version>
         <relativePath />
     </parent>
 

--- a/src/main/java/org/jenkinsci/plugins/slave_setup/Components.java
+++ b/src/main/java/org/jenkinsci/plugins/slave_setup/Components.java
@@ -200,8 +200,8 @@ public class Components {
                 this.closeConfigStream();
                 Components.info("Install " + item.getAssignedLabelString() + " succeded");
             } else
-                Components.info(String.format("%s slave have last version of %s", slave.getName(),
-                        item.getAssignedLabelString()));
+                Components.info("%s slave have last version of %s".formatted(slave.getName(),
+                    item.getAssignedLabelString()));
 
         }
 
@@ -249,7 +249,7 @@ public class Components {
                 Components manager = new Components(slave);
                 manager.doConfig();
             } catch (Exception ex) {
-                Components.info(String.format("Failed to configure %s%nErr:%s", slave.getName(), ex.getMessage()));
+                Components.info("Failed to configure %s%nErr:%s".formatted(slave.getName(), ex.getMessage()));
                 succeded = false;
             }
         }
@@ -274,7 +274,7 @@ public class Components {
                 Components manager = new Components(slave);
                 manager.doSetup();
             } catch (Exception ex) {
-                Components.info(String.format("Failed to configure %s%nErr:%s", slave.getName(), ex.getMessage()));
+                Components.info("Failed to configure %s%nErr:%s".formatted(slave.getName(), ex.getMessage()));
                 succeded = false;
             }
         }
@@ -337,7 +337,7 @@ public class Components {
     private void closeConfigStream() throws IOException, InterruptedException {
         if (getCache().size() > 0) {
             Components.debug(
-                    String.format("Updating %s with%n%s", this.configFile, StringUtils.join(getCache(), "\r\n")));
+                "Updating %s with%n%s".formatted(this.configFile, StringUtils.join(getCache(), "\r\n")));
             configFile.write(StringUtils.join(cache, this.remoteSeparator).trim(), "UTF-8");
         } else
             Components.debug("Nothing to update on slave, stream closed");

--- a/src/main/java/org/jenkinsci/plugins/slave_setup/SetupConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/slave_setup/SetupConfig.java
@@ -11,7 +11,7 @@ import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.io.File;
 import java.text.MessageFormat;
@@ -50,13 +50,13 @@ public class SetupConfig extends GlobalConfiguration {
      * Begin this SetupConfig initialization binding configJson, seting up Listener and performing
      * this config execution on all activeSlaves.
      * 
-     * @param req StaplerRequest from jenkins classes
+     * @param req StaplerRequest2 from jenkins classes
      * @param json JSONObject from jenkins classes
      * 
      * @return Boolean if the config setup for all the slaves went correctly if true.
      */
     @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+    public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
         req.bindJSON(this, json);
         save();
 


### PR DESCRIPTION
## Require Jenkins 2.479.3 or newer

Jenkins 2.479.3 allows us to use Java 17 specific features, moves Jenkins core to Jakarta EE 9, and updates to Spring Security 6.

Remove developer and contributor sections from pom.  Developer list is maintained in [repository permissions updater](https://github.com/jenkins-infra/repository-permissions-updater/blob/master/permissions/plugin-slave-setup.yml).  Contributor list is in the git commit history.

### Testing done

Confirmed that automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
