### PR TITLE
Migrate from Commons Lang to native Java Platform functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <hpi.bundledArtifacts />
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <jenkins.baseline>2.479</jenkins.baseline>
+    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>

--- a/src/main/java/org/jenkinsci/plugins/slave_setup/Components.java
+++ b/src/main/java/org/jenkinsci/plugins/slave_setup/Components.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.slave_setup;
 import hudson.AbortException;
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.Util;
 import hudson.model.Computer;
 import hudson.model.Node;
 import hudson.model.TaskListener;
@@ -10,7 +11,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * We are going to store in cache the master delimiter and each node delimiter
@@ -283,7 +283,7 @@ public class Components {
     private void doDeploy(SetupConfigItem installInfo) throws IOException, InterruptedException {
         EnvVars enviroment = SetupDeployer.createEnvVarsForComputer(this.slave);
 
-        if (!StringUtils.isEmpty(installInfo.getPrepareScript())) {
+        if (Util.fixEmpty(installInfo.getPrepareScript()) != null) {
             // If isn't empty script will execute on master
             validateResponse(SetupDeployer.executeScriptOnMaster(
                     Components.listener, installInfo.getPrepareScript(), enviroment));
@@ -293,7 +293,7 @@ public class Components {
         // Copy files from master to slave (only if option contains some path)
         SetupDeployer.copyFiles(installInfo.getFilesDir(), remotePath);
 
-        if (!StringUtils.isEmpty(installInfo.getCommandLine())) {
+        if (Util.fixEmpty(installInfo.getCommandLine()) != null) {
             // If we had slave script, will call now.
             validateResponse(
                     Utils.multiOsExecutor(Components.listener, installInfo.getCommandLine(), remotePath, enviroment));
@@ -325,8 +325,8 @@ public class Components {
      */
     private void closeConfigStream() throws IOException, InterruptedException {
         if (getCache().size() > 0) {
-            Components.debug("Updating %s with%n%s".formatted(this.configFile, StringUtils.join(getCache(), "\r\n")));
-            configFile.write(StringUtils.join(cache, this.remoteSeparator).trim(), "UTF-8");
+            Components.debug("Updating %s with%n%s".formatted(this.configFile, String.join("\r\n", getCache())));
+            configFile.write(String.join(this.remoteSeparator, cache).trim(), "UTF-8");
         } else Components.debug("Nothing to update on slave, stream closed");
     }
 

--- a/src/main/java/org/jenkinsci/plugins/slave_setup/SetupConfigItem.java
+++ b/src/main/java/org/jenkinsci/plugins/slave_setup/SetupConfigItem.java
@@ -8,7 +8,6 @@ import hudson.model.Descriptor;
 import hudson.model.labels.LabelAtom;
 import hudson.model.labels.LabelExpression;
 import java.io.File;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -165,7 +164,7 @@ public class SetupConfigItem extends AbstractDescribableImpl<SetupConfigItem> {
      * @return assigned label as string
      */
     public String getAssignedLabelString() {
-        if (StringUtils.isEmpty(this.assignedLabelString)) {
+        if (Util.fixEmpty(this.assignedLabelString) == null) {
             return "";
         }
 

--- a/src/main/java/org/jenkinsci/plugins/slave_setup/SetupDeployer.java
+++ b/src/main/java/org/jenkinsci/plugins/slave_setup/SetupDeployer.java
@@ -9,7 +9,6 @@ import hudson.model.TaskListener;
 import java.io.File;
 import java.io.IOException;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Executes a deployment to all or a single node of the given fileset and
@@ -39,7 +38,7 @@ public class SetupDeployer {
      * @throws IOException IO error while accesing disk
      */
     public static boolean copyFiles(File localPath, FilePath remotePath) throws IOException, InterruptedException {
-        if (localPath != null && StringUtils.isNotBlank(localPath.getPath())) {
+        if (localPath != null && Util.fixEmptyAndTrim(localPath.getPath()) != null) {
             Components.info("copying files from " + localPath);
             int tmp = new FilePath(localPath).copyRecursiveTo(remotePath);
             return tmp == 0;

--- a/src/test/java/org/jenkinsci/plugins/slave_setup/SetupDeployerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/slave_setup/SetupDeployerTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.FilePath;
+import hudson.Util;
 import hudson.model.*;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.OfflineCause;
@@ -18,7 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -225,7 +225,7 @@ class SetupDeployerTest {
         assertTrue(setupFiles.canRead() && setupFiles.isDirectory());
         SetupConfigItem item = new SetupConfigItem();
         item.setFilesDir(setupFiles);
-        if (StringUtils.isNotBlank(label)) {
+        if (Util.fixEmptyAndTrim(label) != null) {
             item.setAssignedLabelString(label);
         }
 


### PR DESCRIPTION
No need to use a third-party library when this functionality is available in the Java Platform.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

- `StringUtils.isEmpty` / `isNotEmpty` → the `hudson.Util.fixEmpty*` helpers.
- `StringUtils.join(cache, separator)` → `String.join(separator, cache)`. `cache` is a `List<String>`
  built internally, so it holds no nulls and the two behave identically here.
- Enables the `ban-commons-lang-2` enforcer rule.

Formatting is `mvn spotless:apply` output, since this repository enforces Spotless.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.
The `ban-commons-lang-2` enforcer rule is enabled in this PR, so the build fails if an
`org.apache.commons.lang.*` import comes back.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
